### PR TITLE
Pulling Featured Images Proper Way | WP REST API

### DIFF
--- a/src/app/pages/custom-post-single/custom-post-single.component.html
+++ b/src/app/pages/custom-post-single/custom-post-single.component.html
@@ -4,7 +4,8 @@
             <div class="col-sm-12 text-center mt-5 mb-5">
                 <h1 class="text-dark" style="font-size:3rem!important;" [innerHTML]='customPosts.title.rendered'></h1>
                 <p class="mb-0" style="">{{customPosts.date | date}}</p>
-                 <img src="{{customPosts.better_featured_image.source_url}}" style="width:100%" alt=""> 
+                <img [src]="getFeaturedImage(customPosts)" alt="Featured Image">
+                 <!-- <img src="{{customPosts.better_featured_image.source_url}}" style="width:100%" alt="">  -->
                 <!-- <div *ngFor="let image of posts.images">
                     <img src="{{image.src}}" width="1200" height="800" alt="">
                 </div> -->

--- a/src/app/pages/custom-post-single/custom-post-single.component.ts
+++ b/src/app/pages/custom-post-single/custom-post-single.component.ts
@@ -27,6 +27,12 @@ export class CustomPostSingleComponent implements OnInit {
     });
   }
 
+  // Get the post featured image the proper way without plugin
+getFeaturedImage(customPosts: any): string {
+  console.log(customPosts._embedded['wp:featuredmedia'][0].source_url);
+  return customPosts._embedded['wp:featuredmedia'][0].source_url;
+}
+
   getACFFields(acf: any): { key: string; value: any }[] {
     return Object.keys(acf).map(key => ({ key, value: acf[key] }));
   }

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -88,7 +88,8 @@
                     <div *ngFor="let customPost of customPosts"  data-aos="fade-in">
                         <div class="uk-card uk-card-default">
                             <div class="uk-card-media-top">
-                                <img src="{{customPost.better_featured_image.source_url}}" width="1200" height="800" alt="">
+                                <img [src]="getCustomPostFeaturedImage(customPost)" alt="Featured Image">
+                                <!-- <img src="{{customPost.better_featured_image.source_url}}" width="1200" height="800" alt=""> -->
                             </div>
                             <div class="uk-card-body text-left">
                     

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -70,6 +70,11 @@ export class HomeComponent implements OnInit {
     //console.log(post._embedded['wp:featuredmedia'][0].source_url);
     return post._embedded['wp:featuredmedia'][0].source_url;
   }
+  // Get the post featured image  proper way(without using the plugin)
+  getCustomPostFeaturedImage(customPost: any): string {
+    //console.log(post._embedded['wp:featuredmedia'][0].source_url);
+    return customPost._embedded['wp:featuredmedia'][0].source_url;
+  }
   // Get Product List
   getListOfProducts(): void {
     this.woocommerceService.getListOfProducts()

--- a/src/app/pages/loadmore-onscroll/loadmore-onscroll.component.html
+++ b/src/app/pages/loadmore-onscroll/loadmore-onscroll.component.html
@@ -14,6 +14,7 @@
                         <div *ngFor="let post of posts"  data-aos="fade-in">
                             <div class="uk-card uk-card-default">
                                 <div class="uk-card-media-top">
+                                    <img [src]="getFeaturedImage(post)" alt="Featured Image">
                                     <!-- <img src="{{post.better_featured_image.source_url}}" width="1200" height="800" alt=""> -->
                                 </div>
                                 <div class="uk-card-body text-left">

--- a/src/app/pages/loadmore-onscroll/loadmore-onscroll.component.ts
+++ b/src/app/pages/loadmore-onscroll/loadmore-onscroll.component.ts
@@ -27,6 +27,12 @@ export class LoadmoreOnscrollComponent implements OnInit {
     });
   }
 
+  // Get the post featured image  proper way(without using the plugin)
+  getFeaturedImage(post: any): string {
+    //console.log(post._embedded['wp:featuredmedia'][0].source_url);
+    return post._embedded['wp:featuredmedia'][0].source_url;
+  }
+
   @HostListener('window:scroll', ['$event'])
   onWindowScroll(event: any) {
     const windowHeight = 'innerHeight' in window ? window.innerHeight : document.documentElement.offsetHeight;

--- a/src/app/pages/loadmore/loadmore.component.html
+++ b/src/app/pages/loadmore/loadmore.component.html
@@ -2,12 +2,13 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 mb-5 mt-5">
-                    <h2 class="text-center"  data-aos="fade-in" style="font-size: 3rem;">Load More Posts from WP API</h2>
+                    <h2 class="text-center"  data-aos="fade-in" style="font-size: 3rem;">Load More Posts from WP API On Button Click</h2>
                 </div>
                     <div class="uk-child-width-1-3@m" uk-grid>
                         <div *ngFor="let post of posts"  data-aos="fade-in">
                             <div class="uk-card uk-card-default">
                                 <div class="uk-card-media-top">
+                                    <img [src]="getFeaturedImage(post)" alt="Featured Image">
                                     <!-- <img src="{{post.better_featured_image.source_url}}" width="1200" height="800" alt=""> -->
                                 </div>
                                 <div class="uk-card-body text-left">

--- a/src/app/pages/loadmore/loadmore.component.ts
+++ b/src/app/pages/loadmore/loadmore.component.ts
@@ -29,4 +29,10 @@ export class LoadmoreComponent implements OnInit {
     this.loadPosts();
   }
 
+   // Get the post featured image  proper way(without using the plugin)
+   getFeaturedImage(post: any): string {
+    //console.log(post._embedded['wp:featuredmedia'][0].source_url);
+    return post._embedded['wp:featuredmedia'][0].source_url;
+  }
+
 }

--- a/src/app/pages/pageinate/pageinate.component.html
+++ b/src/app/pages/pageinate/pageinate.component.html
@@ -2,12 +2,13 @@
     <div class="container">
         <div class="row">
             <div class="col-lg-12 mb-5 mt-5">
-                <h2 class="text-center"  data-aos="fade-in" style="font-size: 3rem;">Load More Posts from WP API</h2>
+                <h2 class="text-center"  data-aos="fade-in" style="font-size: 3rem;">Paginate Posts from WP API</h2>
             </div>
                 <div class="uk-child-width-1-3@m" uk-grid>
                     <div *ngFor="let post of posts"  data-aos="fade-in">
                         <div class="uk-card uk-card-default">
                             <div class="uk-card-media-top">
+                              <img [src]="getFeaturedImage(post)" alt="Featured Image">
                                 <!-- <img src="{{post.better_featured_image.source_url}}" width="1200" height="800" alt=""> -->
                             </div>
                             <div class="uk-card-body text-left">

--- a/src/app/pages/pageinate/pageinate.component.ts
+++ b/src/app/pages/pageinate/pageinate.component.ts
@@ -32,6 +32,12 @@ export class PageinateComponent implements OnInit {
       });
     }
 
+    // Get the post featured image  proper way(without using the plugin)
+  getFeaturedImage(post: any): string {
+    //console.log(post._embedded['wp:featuredmedia'][0].source_url);
+    return post._embedded['wp:featuredmedia'][0].source_url;
+  }
+
     goToPage(page: number): void {
      
         this.router.navigate([], {

--- a/src/app/services/env.service.ts
+++ b/src/app/services/env.service.ts
@@ -17,9 +17,9 @@ export class EnvService {
   //Category
   catApiUrl = 'http://localhost/webwarrior/wp-json/wp/v2';
 
-  // Custom post type and single
-  custom_post_single_url = 'http://localhost/webwarrior/wp-json/wp/v2/books'
-  custom_post_url = 'http://localhost/webwarrior/wp-json/wp/v2/books?_embed/'
+    // Custom post type and single (proper featured image way without plugin)
+    custom_post_single_url = 'http://localhost/webwarrior/wp-json/wp/v2/books'
+    custom_post_url = 'http://localhost/webwarrior/wp-json/wp/v2/books?_embed'
 
   // Woocommerce products and single with keys
   product_single_url = 'http://localhost/webwarrior/wp-json/wc/v3/products'
@@ -29,13 +29,17 @@ export class EnvService {
 
   PRODUCT_API_URL = `${this.products_base_url}consumer_key=${this.ck}&consumer_secret=${this.cs}`;
 
-    //Custom Fields
+  //Custom Fields
   // customFieldbaseUrl = 'http://localhost/webwarrior/wp-json/wp/v2';
   // customFieldpostsUrl = `${this.customFieldbaseUrl}/posts`;
 
   //  Simple blog post and single (with featured image plugin)
   // post_single_url = 'http://localhost/webwarrior/wp-json/wp/v2/posts'
   // post_url = 'http://localhost/webwarrior/wp-json/wp/v2/posts?_embed/'
+
+  // Custom post type and single (plugin for featured image)
+  // custom_post_single_url = 'http://localhost/webwarrior/wp-json/wp/v2/books'
+  // custom_post_url = 'http://localhost/webwarrior/wp-json/wp/v2/books?_embed/'
 
   //Pagination first attempt
   // pageinate_url_1 = 'http://localhost/webwarrior/wp-json/wp/v2/posts?page=1&per_page=1'


### PR DESCRIPTION
Pull WP featured images properly (without the use of 3rd party plugins). Applied to rest of the post types in angular services